### PR TITLE
Update the function composition example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ f.call "  localhost:9092     "
 
 # Partially applied lambda:
 my_split = lambda { |str, *args| str.split(*args) }
-f = F . fn(":", &split)
+f = F . fn(":", &my_split) . strip
 f.call "  localhost:9092     "
 # => ["localhost", "9092"]
 ```


### PR DESCRIPTION
We were missing a call to `strip` and the variable name wasn't right.

Also: thanks a lot for this gem :+1: 
