### PR TITLE
Travis: Use a Trusty machine to make build work on JRuby; drop rbx-2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,24 @@
 language: ruby
+
 dist: trusty
+
 rvm:
   - 2.1
   - 2.2
   - 2.3.3
   - 2.4.0
   - jruby-9.1.7.0
-  - rbx-2
   - ruby-head
   - jruby-head
 
+matrix:
+  include:
+    - rvm: jruby-head
+      env: "JRUBY_OPTS=--debug"
+      before_install:
+        - gem install bundler -v'1.13.7'
+    - rvm: jruby-9.1.7.0
+      env: "JRUBY_OPTS=--debug"
+
 script:
-- rake
+  - rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: ruby
+dist: trusty
 rvm:
   - 2.1
   - 2.2
-  - 2.3
+  - 2.3.3
+  - 2.4.0
+  - jruby-9.1.7.0
   - rbx-2
   - ruby-head
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,13 @@ language: ruby
 
 dist: trusty
 
-rvm:
-  - 2.1
-  - 2.2
-  - 2.3.3
-  - 2.4.0
-  - jruby-9.1.7.0
-  - ruby-head
-  - jruby-head
-
 matrix:
   include:
+    - rvm: 2.1
+    - rvm: 2.2
+    - rvm: 2.3.3
+    - rvm: 2.4.0
+    - rvm: ruby-head
     - rvm: jruby-head
       env: "JRUBY_OPTS=--debug"
       before_install:


### PR DESCRIPTION
- add a specific Bundler for jruby-head
- add `--debug` to env for JRubies
- remove the defunkt rbx-2 (which didn't exist at all on the previous build machine)
- update the build machine distribution to 'trusty'
- Add 2.4.0
- Add 2.3.3 (instead of 2.3)