### PR TITLE
Make global namespace explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,26 @@ Future { expensive_operation }.fmap { |x| x * 2 }.await
 # => result of expensive_operation * 2
 ```
 
+## Safe Mode
+
+If you do not want to pollute Ruby's global namespace, you can load Kleisli in safe mode and include the DSL manually. Remember to add `require: false` to the gemfile.
+```ruby
+require "kleisli/safe"
+defined?(F)
+# => nil
+class Example
+  include Kleisli::DSL
+  def f?; defined?(F); end
+  def r7; F . unshift(7) . reverse; end
+end
+Example.new.f?
+# => "constant"
+Example.new.r7.call([1,2,3])
+# => [7, 3, 2, 1]
+defined?(F)
+# => nil
+```
+
 ## Who's this
 
 This was made by [Josep M. Bach (Txus)](http://blog.txus.io) and [Ryan

--- a/lib/kleisli.rb
+++ b/lib/kleisli.rb
@@ -1,3 +1,2 @@
-require "kleisli/version"
-require "kleisli/globals"
+require "kleisli/safe"
 include Kleisli::Globals

--- a/lib/kleisli.rb
+++ b/lib/kleisli.rb
@@ -1,9 +1,3 @@
 require "kleisli/version"
-require "kleisli/maybe"
-require "kleisli/try"
-require "kleisli/future"
-require "kleisli/either"
-require "kleisli/composition"
-
-module Kleisli
-end
+require "kleisli/globals"
+include Kleisli::Globals

--- a/lib/kleisli.rb
+++ b/lib/kleisli.rb
@@ -1,2 +1,2 @@
 require "kleisli/safe"
-include Kleisli::Globals
+include Kleisli::DSL

--- a/lib/kleisli/composition.rb
+++ b/lib/kleisli/composition.rb
@@ -35,5 +35,3 @@ module Kleisli
     end
   end
 end
-
-F = Kleisli::ComposedFn.new

--- a/lib/kleisli/dsl.rb
+++ b/lib/kleisli/dsl.rb
@@ -5,7 +5,7 @@ require "kleisli/try"
 require "kleisli/future"
 
 module Kleisli
-  module Globals
+  module DSL
     ### kleisli/composition ###
     F = Kleisli::ComposedFn.new
 

--- a/lib/kleisli/either.rb
+++ b/lib/kleisli/either.rb
@@ -80,14 +80,3 @@ module Kleisli
     end
   end
 end
-
-Right = Kleisli::Either::Right.method(:new)
-Left = Kleisli::Either::Left.method(:new)
-
-def Right(v)
-  Kleisli::Either::Right.new(v)
-end
-
-def Left(v)
-  Kleisli::Either::Left.new(v)
-end

--- a/lib/kleisli/future.rb
+++ b/lib/kleisli/future.rb
@@ -27,7 +27,3 @@ module Kleisli
     end
   end
 end
-
-def Future(v=nil, &block)
-  Kleisli::Future.lift(v, &block)
-end

--- a/lib/kleisli/globals.rb
+++ b/lib/kleisli/globals.rb
@@ -1,0 +1,44 @@
+require "kleisli/composition"
+require "kleisli/maybe"
+require "kleisli/either"
+require "kleisli/try"
+require "kleisli/future"
+
+module Kleisli
+  module Globals
+    ### kleisli/composition ###
+    F = Kleisli::ComposedFn.new
+
+    ### kleisli/maybe ###
+    Maybe = Kleisli::Maybe.method(:lift)
+    def Maybe(v)
+      Maybe.(v)
+    end
+    def None()
+      Maybe(nil)
+    end
+    def Some(v)
+      Maybe(v)
+    end
+
+    ### kleisli/either ###
+    Right = Kleisli::Either::Right.method(:new)
+    Left  = Kleisli::Either::Left.method(:new)
+    def Right(v)
+      Kleisli::Either::Right.new(v)
+    end
+    def Left(v)
+      Kleisli::Either::Left.new(v)
+    end
+
+    ### kleisli/try ###
+    def Try(&f)
+      Kleisli::Try.lift(f)
+    end
+
+    ### kleisli/future ###
+    def Future(v=nil, &block)
+      Kleisli::Future.lift(v, &block)
+    end
+  end
+end

--- a/lib/kleisli/maybe.rb
+++ b/lib/kleisli/maybe.rb
@@ -72,17 +72,3 @@ module Kleisli
     end
   end
 end
-
-Maybe = Kleisli::Maybe.method(:lift)
-
-def Maybe(v)
-  Maybe.(v)
-end
-
-def None()
-  Maybe(nil)
-end
-
-def Some(v)
-  Maybe(v)
-end

--- a/lib/kleisli/safe.rb
+++ b/lib/kleisli/safe.rb
@@ -1,2 +1,2 @@
 require "kleisli/version"
-require "kleisli/globals"
+require "kleisli/dsl"

--- a/lib/kleisli/safe.rb
+++ b/lib/kleisli/safe.rb
@@ -1,0 +1,2 @@
+require "kleisli/version"
+require "kleisli/globals"

--- a/lib/kleisli/try.rb
+++ b/lib/kleisli/try.rb
@@ -58,7 +58,3 @@ module Kleisli
     end
   end
 end
-
-def Try(&f)
-  Kleisli::Try.lift(f)
-end

--- a/test/kleisli/maybe_test.rb
+++ b/test/kleisli/maybe_test.rb
@@ -6,7 +6,7 @@ class MaybeTest < Minitest::Test
   end
 
   def test_unwrapping_none
-    assert_equal nil, None().value
+    assert_nil None().value
   end
 
   def test_bind_none


### PR DESCRIPTION
It is not always desirable to mutate Ruby's global namespace.
This PR creates a "safe" require, forcing the user to manually include the DSL into the desired scopes (see the README).

The default behavior remains unchanged.