### PR TITLE
fmap supports proc as argument and block

### DIFF
--- a/lib/kleisli/either.rb
+++ b/lib/kleisli/either.rb
@@ -28,8 +28,8 @@ module Kleisli
         f.call(@right)
       end
 
-      def fmap(&f)
-        Right.new(f.call(@right))
+      def fmap(f = nil, &block)
+        Right.new((f || block).call(@right))
       end
 
       def to_maybe
@@ -57,7 +57,7 @@ module Kleisli
         self
       end
 
-      def fmap(&f)
+      def fmap(_f = nil)
         self
       end
 

--- a/lib/kleisli/functor.rb
+++ b/lib/kleisli/functor.rb
@@ -1,6 +1,6 @@
 module Kleisli
   class Functor
-    def fmap(&f)
+    def fmap(_f = nil, &_block)
       raise NotImplementedError, "this functor doesn't implement fmap"
     end
   end

--- a/lib/kleisli/future.rb
+++ b/lib/kleisli/future.rb
@@ -18,8 +18,8 @@ module Kleisli
       f.call(-> { await })
     end
 
-    def fmap(&f)
-      Future.lift(f.call(-> { await }))
+    def fmap(f = nil, &block)
+      Future.lift((f || block).call(-> { await }))
     end
 
     def await

--- a/lib/kleisli/maybe.rb
+++ b/lib/kleisli/maybe.rb
@@ -26,7 +26,7 @@ module Kleisli
     end
 
     class None < Maybe
-      def fmap(&f)
+      def fmap(_f = nil)
         self
       end
 
@@ -53,8 +53,8 @@ module Kleisli
         @value = value
       end
 
-      def fmap(&f)
-        Maybe.lift(f.call(@value))
+      def fmap(f = nil, &block)
+        Maybe.lift((f || block).call(@value))
       end
 
       def >(block)

--- a/lib/kleisli/try.rb
+++ b/lib/kleisli/try.rb
@@ -22,8 +22,8 @@ module Kleisli
         Failure.new(e)
       end
 
-      def fmap(&f)
-        Try { f.call(@value) }
+      def fmap(f = nil, &block)
+        Try { (f || block).call(@value) }
       end
 
       def to_maybe
@@ -44,7 +44,7 @@ module Kleisli
         self
       end
 
-      def fmap(&f)
+      def fmap(_f = nil)
         self
       end
 


### PR DESCRIPTION
It is handy to use a direct passing procs as well as block to fmap fn.

Pros:
* using with regular procs
* using with callable objects