### PR TITLE
Make tests pass on newer Ruby versions

### DIFF
--- a/kleisli.gemspec
+++ b/kleisli.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", ">= 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.5"
 end

--- a/kleisli.gemspec
+++ b/kleisli.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", ">= 1.6"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "minitest", "~> 5.5"
 end

--- a/test/kleisli/composition_test.rb
+++ b/test/kleisli/composition_test.rb
@@ -4,14 +4,14 @@ class CompositionTest < Minitest::Test
   def test_one_method
     f = F . first
     result = f.call([1])
-    assert Fixnum === result, "#{result} is not a number"
+    assert Integer === result, "#{result} is not a number"
     assert_equal 1, result
   end
 
   def test_two_methods
     f = F . first . last
     result = f.call([1, [2,3]])
-    assert Fixnum === result, "#{result} is not a number"
+    assert Integer === result, "#{result} is not a number"
     assert_equal 2, result
   end
 
@@ -20,7 +20,7 @@ class CompositionTest < Minitest::Test
 
     f = F . fn(&my_first)
     result = f.call([1])
-    assert Fixnum === result, "#{result} is not a number"
+    assert Integer === result, "#{result} is not a number"
     assert_equal 1, result
   end
 
@@ -30,7 +30,7 @@ class CompositionTest < Minitest::Test
 
     f = F . fn(&my_first) . fn(&my_last)
     result = f.call([1, [2,3]])
-    assert Fixnum === result, "#{result} is not a number"
+    assert Integer === result, "#{result} is not a number"
     assert_equal 2, result
   end
 
@@ -39,7 +39,7 @@ class CompositionTest < Minitest::Test
 
     f = F . fn { |x| x.first } . fn(&my_last)
     result = f.call([1, [2,3]])
-    assert Fixnum === result, "#{result} is not a number"
+    assert Integer === result, "#{result} is not a number"
     assert_equal 2, result
   end
 
@@ -48,7 +48,7 @@ class CompositionTest < Minitest::Test
 
     f = F . first . fn(&my_last)
     result = f.call([1, [2,3]])
-    assert Fixnum === result, "#{result} is not a number"
+    assert Integer === result, "#{result} is not a number"
     assert_equal 2, result
   end
 

--- a/test/kleisli/maybe_test.rb
+++ b/test/kleisli/maybe_test.rb
@@ -6,7 +6,7 @@ class MaybeTest < Minitest::Test
   end
 
   def test_unwrapping_none
-    assert_equal nil, None().value
+    assert_nil None().value
   end
 
   def test_bind_none


### PR DESCRIPTION
Fixes #31

---

Ruby 3.1: Some actionable output.

```
DEPRECATED: Use assert_nil if expecting nil from /home/runner/work/kleisli/kleisli/test/kleisli/maybe_test.rb:9. This will fail in Minitest 6.
/home/runner/work/kleisli/kleisli/test/kleisli/composition_test.rb:33: warning: constant ::Fixnum is deprecated
/home/runner/work/kleisli/kleisli/test/kleisli/composition_test.rb:51: warning: constant ::Fixnum is deprecated
/home/runner/work/kleisli/kleisli/test/kleisli/composition_test.rb:23: warning: constant ::Fixnum is deprecated
/home/runner/work/kleisli/kleisli/test/kleisli/composition_test.rb:7: warning: constant ::Fixnum is deprecated
/home/runner/work/kleisli/kleisli/test/kleisli/composition_test.rb:14: warning: constant ::Fixnum is deprecated
/home/runner/work/kleisli/kleisli/test/kleisli/composition_test.rb:42: warning: constant ::Fixnum is deprecated
```

Ruby 3.2: needs a newer Rake

```

NoMethodError: undefined method `=~' for #<Proc:0x00007f6b8ff27bd0 /home/runner/work/kleisli/kleisli/vendor/bundle/ruby/3.2.0/gems/rake-10.5.0/lib/rake/application.rb:393 (lambda)>
```

(and the 3.1 output had become errors)